### PR TITLE
Members page: pre-2022 era summary (illustrative, no personal data)

### DIFF
--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -14,4 +14,61 @@
 
 .nav-item.dropdown .fas {
   margin-right: 0.5rem;
-} 
+}
+
+/* Historical members (pre-2022) — illustrative era cards on People page */
+.people-era-archive__intro {
+  max-width: 48rem;
+  margin-bottom: 1.5rem;
+  color: var(--bs-secondary-color, #6c757d);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.people-era-archive__grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .people-era-archive__grid {
+    grid-template-columns: repeat(3, 1fr);
+    align-items: stretch;
+  }
+}
+
+.people-era-archive__card {
+  height: 100%;
+  padding: 1.25rem 1.35rem;
+  border: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.125));
+  border-radius: 0.5rem;
+  background-color: var(--bs-body-bg, #fff);
+  transition: box-shadow 0.2s ease;
+}
+
+.people-era-archive__card:hover {
+  box-shadow: 0 0.25rem 1rem rgba(0, 0, 0, 0.06);
+}
+
+.people-era-archive__period {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.people-era-archive__summary {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--bs-body-color, #212529);
+}
+
+.people-era-archive__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--bs-secondary-color, #6c757d);
+  font-style: italic;
+}

--- a/content/en/people/_index.md
+++ b/content/en/people/_index.md
@@ -26,4 +26,32 @@ sections:
       show_interests: true
       show_role: true
 
+  - block: markdown
+    content:
+      title: Historical members (before 2022)
+      subtitle: Era-based summary for context only; individual profiles are not listed while records are being organized.
+      text: |
+        <section class="people-era-archive" aria-labelledby="people-era-heading-en">
+          <h3 id="people-era-heading-en" class="visually-hidden">Early members by era (illustrative)</h3>
+          <p class="people-era-archive__intro">
+            The three bands below describe scale and composition across development phases. Figures are illustrative, not exact counts.
+          </p>
+          <div class="people-era-archive__grid" role="list">
+            <article class="people-era-archive__card" role="listitem">
+              <h4 class="people-era-archive__period">Before 2000</h4>
+              <p class="people-era-archive__summary">Foundational period: early graduate students and a small number of affiliated trainees; smaller cohort with emphasis on core control research.</p>
+              <p class="people-era-archive__hint">Illustrative scale: on the order of a dozen people (current and graduated combined, same below).</p>
+            </article>
+            <article class="people-era-archive__card" role="listitem">
+              <h4 class="people-era-archive__period">2000 — 2010</h4>
+              <p class="people-era-archive__summary">Growth period: more PhD and Master students and applied projects; broader topics and industry collaboration.</p>
+              <p class="people-era-archive__hint">Illustrative scale: on the order of several dozen people.</p>
+            </article>
+            <article class="people-era-archive__card" role="listitem">
+              <h4 class="people-era-archive__period">2010 — 2020</h4>
+              <p class="people-era-archive__summary">Active period: steady expansion of enrollment and projects; stronger international exchange and a fuller talent pipeline.</p>
+              <p class="people-era-archive__hint">Illustrative scale: on the order of around one hundred people.</p>
+            </article>
+          </div>
+        </section>
 ---

--- a/content/zh/people/_index.md
+++ b/content/zh/people/_index.md
@@ -37,4 +37,33 @@ sections:
       show_interests: true
       show_role: true
       show_social: true
+
+  - block: markdown
+    content:
+      title: 历史时期成员（2022 年前）
+      subtitle: 以下为按年代的示意性汇总，不提供具体人员信息；完整名录仍在整理中。
+      text: |
+        <section class="people-era-archive" aria-labelledby="people-era-heading">
+          <h3 id="people-era-heading" class="visually-hidden">按年代划分的早期成员示意</h3>
+          <p class="people-era-archive__intro">
+            下列三个时段反映实验室在不同发展阶段的成员规模与构成类型，数字与表述均为示意，不代表精确统计。
+          </p>
+          <div class="people-era-archive__grid" role="list">
+            <article class="people-era-archive__card" role="listitem">
+              <h4 class="people-era-archive__period">2000 年以前</h4>
+              <p class="people-era-archive__summary">奠基阶段：以早期研究生与少量联合培养人员为主，规模较小，侧重预测控制等方向的基础积累。</p>
+              <p class="people-era-archive__hint">示意规模：约十余人量级（在读与已毕业合计，下同）。</p>
+            </article>
+            <article class="people-era-archive__card" role="listitem">
+              <h4 class="people-era-archive__period">2000 — 2010</h4>
+              <p class="people-era-archive__summary">扩展阶段：博士、硕士与工程应用课题逐年增多，团队研究方向与工业合作项目逐步丰富。</p>
+              <p class="people-era-archive__hint">示意规模：约数十人量级。</p>
+            </article>
+            <article class="people-era-archive__card" role="listitem">
+              <h4 class="people-era-archive__period">2010 — 2020</h4>
+              <p class="people-era-archive__summary">活跃阶段：招生与课题规模稳定扩大，国际化交流与横向合作进一步增加，人才梯队更加完整。</p>
+              <p class="people-era-archive__hint">示意规模：约近百人量级。</p>
+            </article>
+          </div>
+        </section>
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a second section on the People page (Chinese and English) titled **历史时期成员（2022 年前)** / **Historical members (before 2022)**. It presents three era bands—**2000 年以前**, **2000–2010**, **2010–2020**—as responsive cards with illustrative narrative and rough scale hints only, explicitly stating that individual profiles are not listed while records are organized.

## Changes

- `content/zh/people/_index.md`, `content/en/people/_index.md`: new `markdown` block after the existing `people` block.
- `assets/scss/custom.scss`: BEM-style `.people-era-archive__*` rules for a mobile-first grid (stacked on small screens, three columns from `md` up).

## Testing

- `hugo --gc --minify` (completed successfully; existing Hugo version/module warnings unchanged).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3117055c-4537-4603-b94e-9053a958fa27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3117055c-4537-4603-b94e-9053a958fa27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

