### PR TITLE
zh: 团队页增加「2020年以前人员」三段空标题

### DIFF
--- a/content/zh/people/_index.md
+++ b/content/zh/people/_index.md
@@ -37,4 +37,13 @@ sections:
       show_interests: true
       show_role: true
       show_social: true
+  - block: markdown
+    content:
+      title: 2020年以前人员
+      text: |
+        ### 2010–2020
+
+        ### 2000–2010
+
+        ### 2000年以前
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
在中文 `content/zh/people/_index.md` 的团队成员区块后增加一个 `markdown` 区块，标题为「2020年以前人员」，下分三节：

- 2010–2020
- 2000–2010
- 2000年以前

各节内容暂空，便于后续补录名单。

**说明**：仓库中未找到与「撤回上一次修改」对应的历史内容；按需求实现为「分三部分列出、暂留空」结构。若需回滚某次具体提交或某段已填内容，可说明文件或 commit，以便再改。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a8ba414-2bab-4e4d-a932-bb6eac5d2df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a8ba414-2bab-4e4d-a932-bb6eac5d2df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

