### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a Hugo-based multilingual academic website (SJTU CSC Lab). It uses Hugo v0.135.0 extended with HugoBlox/Wowchemy academic theme and Go modules. There is also a TypeScript MCP server in `mcp-server/`.
+
+### Services
+
+| Service | Command | URL |
+|---------|---------|-----|
+| Hugo dev server | `hugo server --bind 0.0.0.0 --baseURL http://localhost:1313/` | http://localhost:1313/ |
+| MCP server | `cd mcp-server && npm run build && npm start` | stdio (not HTTP) |
+
+### Key commands
+
+- **Dev server**: `hugo server` (default port 1313, hot-reload enabled)
+- **Production build**: `hugo --gc --minify`
+- **Full build with search**: `hugo --gc --minify && npx pagefind --source 'public'`
+- **MCP server build**: `cd mcp-server && npm run build`
+- **MCP server run**: `cd mcp-server && npm start`
+
+### Gotchas
+
+- Hugo requires the **extended** version (for SCSS processing). Standard Hugo will fail at build time.
+- The `hugo.yaml` config references `baseURL: 'https://www.csc-lab.com/'` — use `--baseURL` flag to override for local dev.
+- Hugo modules are vendored in `_vendor/` so `hugo mod vendor` is not needed unless modules are updated in `go.mod`.
+- The root `package.json` only contains `netlify-cms-app` — it is not a Node.js application.
+- The one WARN about "found no layout file for api for kind section" is expected and non-blocking.
+- Default content language is Chinese (`zh`); English is at `/en/`, French at `/fr/`.
+- The JSON API outputs (used by MCP server) are generated at build time at paths like `/en/publication/index.json`.

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -8,7 +8,8 @@
       "name": "csc-lab-mcp-server",
       "version": "1.0.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0"
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "zod": "^3.23.0"
       },
       "bin": {
         "csc-lab-mcp": "dist/index.js"
@@ -1066,9 +1067,10 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "csc-lab",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents working on this codebase.

## What's included

- Overview of the project (Hugo-based multilingual academic site + MCP server)
- Service commands table (Hugo dev server, MCP server)
- Key development commands (dev server, production build, search indexing)
- Non-obvious gotchas discovered during environment setup (extended Hugo requirement, vendored modules, base URL override, expected WARN messages, etc.)

## Environment Setup Verified

| Check | Status |
|-------|--------|
| Hugo v0.135.0 extended installed | ✅ |
| npm install (root) | ✅ |
| npm install (mcp-server) | ✅ |
| Hugo dev server (`hugo server`) | ✅ |
| Hugo production build (`hugo --gc --minify`) | ✅ |
| Pagefind search index | ✅ |
| MCP server build (`npm run build`) | ✅ |
| JSON API endpoints | ✅ |
| Multilingual pages (zh/en/fr) | ✅ |

## Demo

[hugo_site_demo.mp4](https://cursor.com/agents/bc-3385c897-7f19-4e33-992f-59e65dda0f74/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhugo_site_demo.mp4)

[English homepage](https://cursor.com/agents/bc-3385c897-7f19-4e33-992f-59e65dda0f74/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenglish_homepage.webp)
[Publications page](https://cursor.com/agents/bc-3385c897-7f19-4e33-992f-59e65dda0f74/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpublications_page.webp)
[Chinese homepage](https://cursor.com/agents/bc-3385c897-7f19-4e33-992f-59e65dda0f74/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchinese_homepage.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3385c897-7f19-4e33-992f-59e65dda0f74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3385c897-7f19-4e33-992f-59e65dda0f74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

