### PR TITLE
Update 金碧辉 undergraduate program label to 自动化/教改联读班

### DIFF
--- a/content/zh/authors/bihui-jin/_index.md
+++ b/content/zh/authors/bihui-jin/_index.md
@@ -21,7 +21,7 @@ education:
     - course: 硕士学位（能源）
       institution: 巴黎理工学院 (École Polytechnique)
       year: 2012
-    - course: 自动化（联读班）本科
+    - course: 自动化/教改联读班本科
       institution: 上海交通大学
       year: 2009
 email: bihui.jin@gmail.com


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Chinese author profile education line for 金碧辉 (bihui-jin) from `自动化（联读班）本科` to `自动化/教改联读班本科` so the program name matches the intended wording.

## Change

- `content/zh/authors/bihui-jin/_index.md`: education course label only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d472b8d2-53f6-4336-8051-90c381c684f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d472b8d2-53f6-4336-8051-90c381c684f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

