### PR TITLE
Refresh CSC Lab website identity

### DIFF
--- a/assets/media/logo.svg
+++ b/assets/media/logo.svg
@@ -16,5 +16,5 @@
 
   <text x="44" y="25" fill="#102f4a" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="22" font-weight="760" letter-spacing="0.4">CSC LAB</text>
   <rect x="44" y="30" width="164" height="1.4" rx="0.7" fill="#a51c30"/>
-  <text x="44" y="39" fill="#486477" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="6.4" font-weight="650" letter-spacing="0.72">SJTU · COMPLEX SYSTEMS &amp; CONTROL</text>
+  <text x="44" y="40" fill="#3d5d72" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="7.5" font-weight="700" letter-spacing="0.32">SJTU · COMPLEX SYSTEMS &amp; CONTROL</text>
 </svg>

--- a/assets/media/logo.svg
+++ b/assets/media/logo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="218" height="44" viewBox="0 0 218 44" role="img" aria-labelledby="title desc">
+  <title id="title">SJTU CSC Lab</title>
+  <desc id="desc">Complex Systems and Control Laboratory at Shanghai Jiao Tong University</desc>
+
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M32 9.5a15 15 0 1 0 0 25" stroke="#a51c30" stroke-width="3.2"/>
+    <path d="M32 9.5l-1.1 5.1 5-1.5" fill="#a51c30" stroke="#a51c30" stroke-width="1"/>
+    <path d="M12.5 22h9.5m0 0 6.5-7m-6.5 7 6.5 7" stroke="#087da8" stroke-width="1.8"/>
+  </g>
+  <g fill="#087da8">
+    <circle cx="12.5" cy="22" r="2.7"/>
+    <circle cx="22" cy="22" r="2.7"/>
+    <circle cx="28.5" cy="15" r="2.7"/>
+    <circle cx="28.5" cy="29" r="2.7"/>
+  </g>
+
+  <text x="44" y="25" fill="#102f4a" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="22" font-weight="760" letter-spacing="0.4">CSC LAB</text>
+  <rect x="44" y="30" width="164" height="1.4" rx="0.7" fill="#a51c30"/>
+  <text x="44" y="39" fill="#486477" font-family="Inter, 'Helvetica Neue', Arial, sans-serif" font-size="6.4" font-weight="650" letter-spacing="0.72">SJTU · COMPLEX SYSTEMS &amp; CONTROL</text>
+</svg>

--- a/assets/scss/custom.scss
+++ b/assets/scss/custom.scss
@@ -2,6 +2,23 @@
   margin-left: auto;
 }
 
+// Compact academic wordmark: keep the full lab identity visible without
+// crowding the navigation links.
+#navbar-main .navbar-brand img {
+  width: 218px;
+  height: 44px;
+  max-width: 218px;
+  object-fit: contain;
+}
+
+@media (max-width: 991.98px) {
+  #navbar-main .navbar-brand img {
+    width: 188px;
+    height: 38px;
+    max-width: 188px;
+  }
+}
+
 .dropdown-menu-end {
   right: 0;
   left: auto;
@@ -14,4 +31,4 @@
 
 .nav-item.dropdown .fas {
   margin-right: 0.5rem;
-} 
+}

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -5,7 +5,7 @@
 
 # Appearance
 
-logo: '/media/icon.png'  # Path to your lab logo image
+logo: '/media/logo.svg'
 
 appearance:
   theme_day: minimal
@@ -44,6 +44,9 @@ header:
     show_day_night: true
     show_search: true
     highlight_active_link: true
+  image:
+    width: 218
+    height: 44
 
 
 # Site footer

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -7,12 +7,13 @@ type: landing
 sections:
   - block: hero
     content:
-      title: |
-        <span style="font-size: 24px; font-weight: bold;">Complex System and Control</span>
+      title: CSC Lab
       image:
         filename: welcome.jpg
       text: |
-        Welcome to our research hub **CSC Laboratory**, where innovation meets excellence. Our interdisciplinary team is dedicated to pushing the boundaries of technological advancement across multiple domains. 
+        **Complex Systems & Control Laboratory**
+
+        Led by Prof. Dewei Li at Shanghai Jiao Tong University, CSC Lab conducts research in model predictive control, autonomous robotics, intelligent transportation, and industrial process optimization and control.
 
     design:
       background:

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -6,12 +6,13 @@ type: landing
 sections:
   - block: hero
     content:
-      title: |
-        <span style="font-size: 24px; font-weight: bold;">Complex System and Control</span>
+      title: CSC Lab
       image:
         filename: welcome.jpg
       text: |
-        Bienvenue au **CSC Laboratory** de l'Université Jiao Tong de Shanghai. Notre équipe interdisciplinaire mène des recherches en robotique, commande prédictive et intelligence artificielle.
+        **Laboratoire de commande des systèmes complexes**
+
+        Dirigé par le professeur Dewei Li à l'Université Jiao Tong de Shanghai, le CSC Lab mène des recherches en commande prédictive, robotique autonome, transport intelligent et optimisation des procédés industriels.
     design:
       background:
         gradient_end: '#1976d2'

--- a/content/zh/_index.md
+++ b/content/zh/_index.md
@@ -7,11 +7,13 @@ type: landing
 sections:
   - block: hero
     content:
-      title: CSC-Lab
+      title: CSC Lab
       image:
         filename: welcome.jpg
       text: |
-        欢迎来到上海交大CSC实验室。我们拥有跨领域的学术与技术团队，致力于在突破自主机器人/先进控制领域边界，共创未来。
+        **Complex Systems & Control Laboratory**
+
+        上海交通大学复杂系统智能控制实验室由李德伟长聘教授领导，围绕模型预测控制、自主机器人、智能交通与工业过程优化控制开展研究。
 
     design:
       background:


### PR DESCRIPTION
## What changed

- add a compact SVG wordmark for the navigation bar
- make `CSC LAB` the primary mark with `SJTU · COMPLEX SYSTEMS & CONTROL` as the descriptor
- use a network-and-feedback-loop symbol to represent complex systems and control
- state the full laboratory identity prominently in the Chinese, English, and French home-page hero sections
- keep the Midea joint laboratory only in the existing industry-collaboration/project record; it is not used in the CSC Lab identity

## Design rationale

The previous logo file was not in the asset location read by the Hugo Blox navbar, so the site fell back to oversized text. The new vector wordmark fits the header on desktop and mobile while making the meaning of CSC explicit.

## Validation

- SVG is valid XML
- YAML front matter/config parsed successfully
- `git diff --check` passed
- pending Netlify visual verification