### PR TITLE
Preserve legacy publication URLs

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,6 @@
+/en/publication/ma-2025-event/ /en/publication/ma-eventtriggereddistributedmodel-2024/ 301
+/zh/publication/ma-2025-event/ /zh/publication/ma-eventtriggereddistributedmodel-2024/ 301
+/en/publication/yang-2025-input/ /en/publication/yang-inputmappingbaseddatadriven-2022/ 301
+/zh/publication/yang-2025-input/ /zh/publication/yang-inputmappingbaseddatadriven-2022/ 301
+/en/publication/zhang-2024-online/ /en/publication/zhang-onlinedatadriveninput-2024/ 301
+/zh/publication/zhang-2024-online/ /zh/publication/zhang-onlinedatadriveninput-2024/ 301


### PR DESCRIPTION
## What changed

Add six explicit Netlify 301 redirects for the three duplicate publication records consolidated in #92, covering Chinese and English URLs.

## Why

The Hugo configuration sets `disableAliases: true`, so front-matter aliases are not emitted during the production build. Without explicit redirects, the removed duplicate URLs return 404.

## Validation

- redirect sources match the six removed bilingual paths
- redirect destinations are the canonical live publication pages
- no wildcard rules are used